### PR TITLE
feat: add fastify v5 as supported version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fastify-plugin": "^3.0.0"
   },
   "peerDependencies": {
-    "fastify": "^4.1.0"
+    "fastify": "^4.1.0 || ^5.0.0"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^17.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,5 +79,5 @@ const plugin: FastifyPluginAsync<Config> = async function fastifyCronPlugin(
 
 export default fp(plugin, {
   name: 'fastify-cron',
-  fastify: '4.x'
+  fastify: '4.x || 5.x'
 })


### PR DESCRIPTION
Tests still seem to pass for both v4 and v5. I don't think this plugin is affected by any breaking changes so updating `fastify-plugin` might not be necessary